### PR TITLE
feat: add animation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 BottomSheet Changelog
 ==================
 
+#### v2.1.0
+- Add animation option (thx @deermichel)
+
 #### v2.0.0
 - Implementation of the "options" system
 - Add noDragIndicator option

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NEW VERSION IS RELEASED! TO FIX YOUR CODE, PLEASE READ THE README.md AGAIN
+# NEW VERSION HAS BEEN RELEASED! TO FIX YOUR CODE, PLEASE READ THE README.md AGAIN
 
 ![SwiftUI BottomSheet](Assets/logo.png)
 ======================================
@@ -24,7 +24,7 @@ A sliding Sheet from the bottom of the Screen with 3 States build with SwiftUI
 
 There have been many different attempts to recreate the BottomSheet from Apple Maps, Shortcuts and Apple Music, because Apple unfortunately does not provide it in their SDK.
 
-However, all previous attempts have a common problem: The **hight does not change** in the different states. Thus, the BottomSheet is always the same size (e.g. 800px) and thus remains 800px, even if you only see e.g. 400px - the rest is **inaccessible** unless you pull the BottomSheet up to the very top.
+However, all previous attempts share a common problem: The **height does not change** in the different states. Thus, the BottomSheet is always the same size (e.g. 800px) and thus remains 800px, even if you only see e.g. 400px - the rest is **inaccessible** unless you pull the BottomSheet up to the very top.
 
 There are also many implementations out there that **only have 2 states** - **not 3** like e.g. Apple Maps.
 
@@ -35,7 +35,7 @@ There are also many implementations out there that **only have 2 states** - **no
 - Very **easy to use**
 - Support for **SearchBar** in the header
 - Flick through feature
-- Same behavoir as Apple for the `.bottom` position
+- Same behavior as Apple for the `.bottom` position
 - Beatuiful **animations**
 
 #### Here are some alternatives:
@@ -148,6 +148,8 @@ struct ContentView: View {
 `mainContent`: A view that is used as main content for the BottomSheet.
 
 ## Options
+
+`.animation(Animation)` Sets the animation for opening and closing the BottomSheet.
 
 `.backgroundBlur` Blurs the background when pulling up the BottomSheet.
 

--- a/Sources/BottomSheet/BottomSheet.swift
+++ b/Sources/BottomSheet/BottomSheet.swift
@@ -14,6 +14,8 @@ public struct BottomSheet {
             return lhs.rawValue == rhs.rawValue
         }
         
+        ///Sets the animation for opening and closing the BottomSheet.
+        case animation(Animation)
         ///Blurs the background when pulling up the BottomSheet.
         case backgroundBlur
         ///Changes the color of the drag indicator.
@@ -50,6 +52,8 @@ public struct BottomSheet {
          */
         public var rawValue: String {
             switch self {
+            case .animation:
+                return "animation"
             case .backgroundBlur:
                 return "backgroundBlur"
             case .dragIndicatorColor:
@@ -72,6 +76,18 @@ public struct BottomSheet {
 }
 
 internal extension Array where Element == BottomSheet.Options {
+    var animation: Animation {
+        var animation = Animation.spring(response: 0.5, dampingFraction: 0.75, blendDuration: 1)
+        
+        self.forEach { item in
+            if case .animation(let customAnimation) = item {
+                animation = customAnimation
+            }
+        }
+        
+        return animation
+    }
+    
     var backgroundBlur: Bool {
         self.contains(BottomSheet.Options.backgroundBlur)
     }

--- a/Sources/BottomSheet/BottomSheetView.swift
+++ b/Sources/BottomSheet/BottomSheetView.swift
@@ -125,7 +125,7 @@ internal struct BottomSheetView<hContent: View, mContent: View, bottomSheetPosit
             .frame(width: geometry.size.width, height: max((geometry.size.height * self.bottomSheetPosition.rawValue) - self.translation, 0), alignment: .top)
             .offset(y: self.isHiddenPosition() ? geometry.size.height + geometry.safeAreaInsets.bottom : self.isBottomPosition() ? geometry.size.height - (geometry.size.height * self.bottomSheetPosition.rawValue) + self.translation + geometry.safeAreaInsets.bottom : geometry.size.height - (geometry.size.height * self.bottomSheetPosition.rawValue) + self.translation)
             .transition(.move(edge: .bottom))
-            .animation(Animation.spring(response: 0.5, dampingFraction: 0.75, blendDuration: 1))
+            .animation(self.options.animation)
         }
     }
     


### PR DESCRIPTION
Closes #12.

As dicussed, this PR adds a new options case `.animation(Animation)` to allow custom animations for opening and closing the BottomSheet.

This is not a breaking change, but introduces a new feature, that's why I bumped the version to 2.1.0.

(... also includes some minor typo fixes in the README)