### PR TITLE
Fixes unsupported iOSApplicationExtension target in XCode 13 Beta 3

### DIFF
--- a/Sources/BottomSheet/BottomSheetView.swift
+++ b/Sources/BottomSheet/BottomSheetView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(iOSApplicationExtension, unavailable)
 internal struct BottomSheetView<hContent: View, mContent: View, bottomSheetPositionEnum: RawRepresentable>: View where bottomSheetPositionEnum.RawValue == CGFloat, bottomSheetPositionEnum: CaseIterable {
     
     @State private var translation: CGFloat = 0
@@ -251,6 +252,7 @@ internal struct BottomSheetView<hContent: View, mContent: View, bottomSheetPosit
     }
 }
 
+@available(iOSApplicationExtension, unavailable)
 internal extension BottomSheetView where hContent == ModifiedContent<ModifiedContent<Text, _EnvironmentKeyWritingModifier<Optional<Int>>>, _PaddingLayout> {
     init(bottomSheetPosition: Binding<bottomSheetPositionEnum>, options: [BottomSheet.Options], title: String?, @ViewBuilder content: () -> mContent) {
         if title == nil {

--- a/Sources/BottomSheet/ViewExtension.swift
+++ b/Sources/BottomSheet/ViewExtension.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(iOSApplicationExtension, unavailable)
 public extension View {
     /**
      A modifer to add a BottomSheet to your view.


### PR DESCRIPTION
According to [this](https://forums.swift.org/t/set-application-extension-api-only-on-a-spm-package/39333) thread every method that calls another method that is not available on iOSApplicationExtension target must also be annoted with @available(iOSApplicationExtension, unavailable). One possible solution would be to exclude BottomSheet from iOSApplicationExtension