### PR TITLE
Fix generic type shadowing to avoid Swift 6 incompatibility

### DIFF
--- a/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+CustomBackground.swift
+++ b/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+CustomBackground.swift
@@ -179,10 +179,10 @@ public extension BottomSheet {
     ///     The last view that you list appears at the front of the stack.
     ///
     /// - Returns: A view that uses the specified content as a background.
-    func customBackground<V>(
+    func customBackground<Content: View>(
         alignment: Alignment = .center,
-        @ViewBuilder content: () -> V
-    ) -> BottomSheet where V: View {
+        @ViewBuilder content: () -> Content
+    ) -> BottomSheet {
         self.configuration.backgroundView = AnyView(content())
         self.configuration.backgroundViewID = UUID()
         return self


### PR DESCRIPTION
### What’s changed

Renamed the generic type in `customBackground()` to `Content` to avoid shadowing `V` from the surrounding type. This prevents a compiler error in Swift 6, where generic type shadowing is disallowed. This change ensures future compatibility.