### PR TITLE
Add new viewModifier isHitTestAllowed

### DIFF
--- a/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+HitTestAllowed.swift
+++ b/Sources/BottomSheet/BottomSheet+ViewModifiers/BottomSheet+HitTestAllowed.swift
@@ -1,0 +1,25 @@
+//
+//  BottomSheet+HitTestAllowed.swift
+//
+//  Created by Pavel Alekseev.
+//  Copyright © 2025 Pavel Alekseev. All rights reserved.
+//
+
+import Foundation
+
+public extension BottomSheet {
+    
+    /// Override whether the background allows hit testing, independent of tap-to-dismiss setting.
+    ///
+    /// When enabled, users can tap through the BottomSheet background even if tap-to-dismiss is disabled.
+    /// When disabled, the background blocks tap events even if tap-to-dismiss is enabled.
+    ///
+    /// - Parameters:
+    ///   - bool: A boolean whether hit testing is allowed on the background.
+    ///
+    /// - Returns: A BottomSheet with custom hit testing behavior.
+    func hitTestAllowed(_ bool: Bool) -> BottomSheet {
+        self.configuration.isHitTestAllowed = bool
+        return self
+    }
+}

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+HelperViews.swift
@@ -25,7 +25,7 @@ internal extension BottomSheetView {
             .edgesIgnoringSafeArea(.all)
         // Make the background tap-able for `tapToDismiss`
             .contentShape(Rectangle())
-            .allowsHitTesting(self.configuration.isTapToDismissEnabled)
+            .allowsHitTesting(self.configuration.isHitTestAllowed ?? self.configuration.isTapToDismissEnabled)
             .onTapGesture(perform: self.tapToDismissAction)
         // Make the background transition via opacity
             .transition(.opacity)

--- a/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
+++ b/Sources/BottomSheet/Models/BottomSheetConfiguration.swift
@@ -26,6 +26,7 @@ internal class BottomSheetConfiguration: Equatable {
         lhs.isResizable == rhs.isResizable &&
         lhs.isSwipeToDismissEnabled == rhs.isSwipeToDismissEnabled &&
         lhs.isTapToDismissEnabled == rhs.isTapToDismissEnabled &&
+        lhs.isHitTestAllowed == rhs.isHitTestAllowed &&
         lhs.iPadFloatingSheet == rhs.iPadFloatingSheet &&
         lhs.sheetWidth == rhs.sheetWidth &&
         lhs.accountForKeyboardHeight == rhs.accountForKeyboardHeight
@@ -54,6 +55,7 @@ internal class BottomSheetConfiguration: Equatable {
     var isResizable: Bool = true
     var isSwipeToDismissEnabled: Bool = false
     var isTapToDismissEnabled: Bool = false
+    var isHitTestAllowed: Bool? = nil
     var onDismiss: () -> Void = {}
     var onDragEnded: (DragGesture.Value) -> Void = { _ in }
     var onDragChanged: (DragGesture.Value) -> Void = { _ in }


### PR DESCRIPTION
If for some reason I want a bottom sheet with isDismissOnTap disabled, I'll be able to click through the background view. Which seems very weird, especially if you add a background blur to it. 

this new modifier will allow to disable this behavior.