### PR TITLE
Fix rotation lock

### DIFF
--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
@@ -186,7 +186,7 @@ internal extension BottomSheetView {
         if self.isIPad {
             // On iPad use 30% of the width
             return geometry.size.width * 0.3
-        } else if UIDevice.current.userInterfaceIdiom == .phone && UIDevice.current.orientation.isLandscape {
+        } else if (UIDevice.current.userInterfaceIdiom == .phone && UIDevice.current.orientation.isLandscape) || bundleOrientationLock() == .unlocked || bundleOrientationLock() == .landscapeOnly {
             // On iPhone landscape use 40% of the width
             return geometry.size.width * 0.4
         } else {

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView+Calculations.swift
@@ -186,7 +186,7 @@ internal extension BottomSheetView {
         if self.isIPad {
             // On iPad use 30% of the width
             return geometry.size.width * 0.3
-        } else if (UIDevice.current.userInterfaceIdiom == .phone && UIDevice.current.orientation.isLandscape) || bundleOrientationLock() == .unlocked || bundleOrientationLock() == .landscapeOnly {
+        } else if UIDevice.current.userInterfaceIdiom == .phone && UIDevice.current.orientation.isLandscape && (bundleOrientationLock() == .unlocked || bundleOrientationLock() == .landscapeOnly) {
             // On iPhone landscape use 40% of the width
             return geometry.size.width * 0.4
         } else {

--- a/Sources/BottomSheet/Helper/OrientationHelper.swift
+++ b/Sources/BottomSheet/Helper/OrientationHelper.swift
@@ -1,0 +1,53 @@
+//
+//  OrientationHelper.swift
+//  BottomSheet
+//
+//  Created by Pedro Cavaleiro on 27/08/2025.
+//
+
+#if os(iOS)
+import UIKit
+
+enum BundleOrientationLock {
+    case portraitOnly
+    case landscapeOnly
+    case unlocked
+}
+
+func bundleOrientationLock() -> BundleOrientationLock {
+    let info = Bundle.main.infoDictionary
+
+    // Grab iPhone orientations first, fallback to iPad
+    let iPhoneOrientations = info?["UISupportedInterfaceOrientations"] as? [String] ?? []
+    let iPadOrientations = info?["UISupportedInterfaceOrientations~ipad"] as? [String] ?? []
+
+    let orientations = !iPhoneOrientations.isEmpty ? iPhoneOrientations : iPadOrientations
+
+    // Map strings into orientation masks
+    let masks: [UIInterfaceOrientationMask] = orientations.compactMap { str in
+        switch str {
+        case "UIInterfaceOrientationPortrait":
+            return .portrait
+        case "UIInterfaceOrientationPortraitUpsideDown":
+            return .portraitUpsideDown
+        case "UIInterfaceOrientationLandscapeLeft":
+            return .landscapeLeft
+        case "UIInterfaceOrientationLandscapeRight":
+            return .landscapeRight
+        default:
+            return nil
+        }
+    }
+
+    if masks.count == 1 {
+        if masks.contains(.portrait) || masks.contains(.portraitUpsideDown) {
+            return .portraitOnly
+        } else if masks.contains(.landscapeLeft) || masks.contains(.landscapeRight) {
+            return .landscapeOnly
+        }
+    }
+
+    return .unlocked
+}
+
+#endif


### PR DESCRIPTION
Detect orientation lock settings from the app bundle and uses this information to refine how the bottom sheet width is calculated on iPhones in landscape mode. The main improvement is that the bottom sheet will only use 40% of the width in iPhone landscape if the orientation lock is either unlocked or set to landscape-only, ensuring better adaptation to app orientation constraints.

Orientation lock detection:

* Added new file `OrientationHelper.swift` with the `bundleOrientationLock()` function, which reads the app's supported interface orientations from the bundle and determines if the orientation is portrait-only, landscape-only, or unlocked.

Bottom sheet width calculation refinement:

* Updated the iPhone landscape width calculation in `BottomSheetView+Calculations.swift` to only apply the 40% width rule if the orientation lock is unlocked or landscape-only, improving compatibility with apps that restrict orientation.